### PR TITLE
KT WiFi 6D 지원 여부 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ KT GiGA WiFi/iptime/ASUSWRT/OpenWrt/넷기어/시놀로지RT/Ubiquiti UniFi/기�
 |DV02-012H<br>GiGA WiFi home ax|〇|〇|✕|
 |HR08-407H<br>GiGA WiFi home ax|〇|✕|〇|
 |AR06-012H<br>GiGA WiFi home ax|〇|✕|✕|
-|KM18-311H<br>KT WiFi 6D|？|？|？|
+|KM18-311H<br>KT WiFi 6D|〇|〇|？|
 |KB01-411H<br>KT WiFi 7D|？|？|？|
 
 __표에서 확인할 수 없는 모델의 각 기능 사용 가능여부를 여러분의 제보(Issues, 메일주소 3570kgen@naver.com , 기여자에 대한 기록을 남기고 싶을경우 Pull Request 등)를 통해 보충할 수 있게 해주세요!__


### PR DESCRIPTION
우선 저희집 인터넷이 아닌 아는 형님의 1G 인터넷 회선이라 TR-069 여부는 확인을 하지는 못했습니다.

수동 IP 할당 설정, 수동IP설정(기기에서) 까지는 IP 주소가 달라지는 것을 확인하였습니다. (첨부한 사진에 다 나와있습니다.) (사실 몇 달전에 확인은 했지만 제보는 이제야 합니다.)
공유기 재부팅은 하지 않았고 로그에서 Update 또는 Upgrade 문구는 보이지 않았습니다.

TCP 53 은 포트포워딩 성공해서 열리나 UDP 53 은 저희집 SKB 처럼 Blocked 된거 같습니다.

![1  시스템 정보](https://github.com/user-attachments/assets/3bdab3ca-583c-4109-97f7-46e2c2db6c29)
![2  ip고정 전의 사설ip](https://github.com/user-attachments/assets/ad060665-0531-490b-ad16-471ee93a77a8)
![3  ip 고정 전의 공인ip](https://github.com/user-attachments/assets/280e1db6-e966-4551-85b5-c2ef17729068)
![4  ip 고정](https://github.com/user-attachments/assets/7c11454a-a5bb-48fa-8e25-ab3ffe14f6f0)
![5  ip 고정 후의 사설ip](https://github.com/user-attachments/assets/2de2a618-303e-4796-8cc6-13d4323bfc85)
![6  ip 고정 후의 공인ip](https://github.com/user-attachments/assets/0c290066-aa49-4453-aa66-a3bfa6631a48)
![7  로그정보](https://github.com/user-attachments/assets/ea952c05-407f-4bc6-9566-b67a32d4cf25)
![8  기기 사설ip 고정](https://github.com/user-attachments/assets/cebd7390-cdc0-43bb-8db3-ab8796299ef7)
![9  기기 사설ip 고정 후의 공인ip](https://github.com/user-attachments/assets/66c9d941-a7c1-48d8-a09a-f5098eed26fe)